### PR TITLE
Fix class creation to be an atomic transaction

### DIFF
--- a/readerclasscode.txt
+++ b/readerclasscode.txt
@@ -1,21 +1,21 @@
 import React, { useState, useEffect, useMemo, useCallback, createContext, useContext } from 'react';
 import { initializeApp } from 'firebase/app';
-import { 
-    getAuth, 
-    onAuthStateChanged, 
+import {
+    getAuth,
+    onAuthStateChanged,
     signOut,
     signInAnonymously,
     signInWithCustomToken
 } from 'firebase/auth';
-import { 
-    getFirestore, 
-    doc, 
-    setDoc, 
-    getDoc, 
-    addDoc, 
-    collection, 
-    query, 
-    where, 
+import {
+    getFirestore,
+    doc,
+    setDoc,
+    getDoc,
+    addDoc,
+    collection,
+    query,
+    where,
     onSnapshot,
     getDocs,
     serverTimestamp,
@@ -74,7 +74,7 @@ export default function App() {
     const [error, setError] = useState('');
     const [currentView, setCurrentView] = useState('loading'); // loading, profileCreation, studentDashboard, teacherDashboard, reader, classRoster
     const [currentClass, setCurrentClass] = useState(null);
-    
+
     const firebaseConfig = useMemo(() => typeof __firebase_config !== 'undefined' ? JSON.parse(__firebase_config) : null, []);
     const appId = useMemo(() => typeof __app_id !== 'undefined' ? __app_id : 'default-app-id', []);
 
@@ -129,7 +129,7 @@ export default function App() {
                     }
                 }
             });
-            
+
             return () => unsubscribe();
 
         } catch (e) {
@@ -185,7 +185,7 @@ export default function App() {
         setCurrentView('profileCreation');
         setCurrentClass(null);
     };
-    
+
     const navigate = (view, classData = null) => {
         setCurrentView(view);
         setCurrentClass(classData);
@@ -215,7 +215,7 @@ export default function App() {
                 return <ProfileCreationScreen onCreateProfile={handleCreateProfile} error={error} />;
         }
     }
-    
+
     const contextValue = {
         auth, db, user, userData, appId, isLoading,
         handleLogout, navigate, currentClass,
@@ -309,31 +309,59 @@ function TeacherDashboard() {
         if (!newClassName.trim() || !db || !user) return;
 
         const generateClassCode = () => {
-            const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Unambiguous uppercase chars
+            const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
             let result = '';
             for (let i = 0; i < 6; i++) {
                 result += chars.charAt(Math.floor(Math.random() * chars.length));
             }
             return result;
         };
-        const classCode = generateClassCode();
 
-        // Create the main class document
-        const classRef = await addDoc(collection(db, `/artifacts/${appId}/public/data/classes`), {
-            className: newClassName,
-            teacherId: user.uid,
-            teacherName: userData?.name || 'Teacher',
-            classCode: classCode,
-            createdAt: serverTimestamp(),
-        });
-        
-        // Create the public lookup document for joining
-        const lookupRef = doc(db, `/artifacts/${appId}/public/data/classCodeDirectory`, classCode);
-        await setDoc(lookupRef, { classId: classRef.id });
+        try {
+            await runTransaction(db, async (transaction) => {
+                let classCode;
+                let isUnique = false;
+                let attempts = 0;
 
+                // Attempt to generate a unique class code, max 10 tries.
+                while (!isUnique && attempts < 10) {
+                    classCode = generateClassCode();
+                    const lookupDocRef = doc(db, `/artifacts/${appId}/public/data/classCodeDirectory`, classCode);
+                    const lookupDoc = await transaction.get(lookupDocRef);
+                    if (!lookupDoc.exists()) {
+                        isUnique = true;
+                    }
+                    attempts++;
+                }
 
-        setNewClassName('');
-        setShowModal(false);
+                if (!isUnique) {
+                    throw new Error("Failed to generate a unique class code. Please try again.");
+                }
+
+                // 1. Create a reference for the new class document.
+                const classRef = doc(collection(db, `/artifacts/${appId}/public/data/classes`));
+
+                // 2. Set the data for the new class.
+                transaction.set(classRef, {
+                    className: newClassName,
+                    teacherId: user.uid,
+                    teacherName: userData?.name || 'Teacher',
+                    classCode: classCode,
+                    createdAt: serverTimestamp(),
+                });
+
+                // 3. Create the public lookup document.
+                const lookupRef = doc(db, `/artifacts/${appId}/public/data/classCodeDirectory`, classCode);
+                transaction.set(lookupRef, { classId: classRef.id });
+            });
+
+            setNewClassName('');
+            setShowModal(false);
+
+        } catch (error) {
+            console.error("Error creating class in transaction:", error);
+            // Optionally: set an error state here to inform the teacher on the UI
+        }
     };
 
     const copyToClipboard = (text, id) => {
@@ -370,7 +398,7 @@ function TeacherDashboard() {
                     Create Class
                 </button>
             </div>
-            
+
             {classes.length === 0 ? (
                 <p className="text-center text-gray-500 mt-10">You haven't created any classes yet. Click "Create Class" to get started.</p>
             ) : (
@@ -427,7 +455,7 @@ function StudentDashboard() {
     useEffect(() => {
         if (!db || !user) return;
         const enrollmentsQuery = query(collection(db, `/artifacts/${appId}/public/data/enrollments`), where("studentId", "==", user.uid));
-        
+
         const unsubscribe = onSnapshot(enrollmentsQuery, async (snapshot) => {
             const classIds = snapshot.docs.map(doc => doc.data().classId);
             if (classIds.length > 0) {
@@ -465,7 +493,7 @@ function StudentDashboard() {
 
         const { classId } = lookupSnap.data();
 
-        const enrollmentsQuery = query(collection(db, `/artifacts/${appId}/public/data/enrollments`), 
+        const enrollmentsQuery = query(collection(db, `/artifacts/${appId}/public/data/enrollments`),
             where("studentId", "==", user.uid),
             where("classId", "==", classId)
         );
@@ -522,7 +550,7 @@ function StudentDashboard() {
                     ))}
                 </div>
             )}
-            
+
             <GamificationProfile userProfile={userData} />
 
             {showModal && (
@@ -596,12 +624,12 @@ function ClassRoster() {
 
     useEffect(() => {
         if (!db || !currentClass) return;
-        
+
         const enrollmentsQuery = query(collection(db, `/artifacts/${appId}/public/data/enrollments`), where("classId", "==", currentClass.id));
-        
+
         const unsubscribe = onSnapshot(enrollmentsQuery, async (snapshot) => {
             const studentIds = snapshot.docs.map(doc => doc.data().studentId);
-            
+
             if (studentIds.length > 0) {
                 const usersQuery = query(collection(db, `/artifacts/${appId}/public/data/users`), where("userId", "in", studentIds));
                 const usersSnapshot = await getDocs(usersQuery);
@@ -628,7 +656,7 @@ function ClassRoster() {
                     View as Teacher
                 </button>
             </header>
-            
+
              <div className="bg-gray-800 p-6 rounded-lg shadow-lg">
                 <h2 className="text-2xl font-bold text-gray-300 mb-4">Enrolled Students ({students.length})</h2>
                 {students.length === 0 ? (
@@ -657,7 +685,7 @@ function ClassRoster() {
 
 function ReaderView() {
     const { navigate, userData, currentClass, storyTitle, storyAuthor, storyText } = useContext(AppContext);
-    
+
     const handleBack = () => {
         if (userData?.role === 'teacher') {
             navigate('classRoster', currentClass);


### PR DESCRIPTION
I saw that the previous implementation of `handleCreateClass` was not atomic. It performed two separate `await` calls, which created a race condition that could leave the class in an unjoinable state.

To resolve this, I've wrapped the logic in a Firestore `runTransaction` block. This ensures that both documents are created together or the entire operation is rolled back, which guarantees data consistency. As part of the transaction, I also added a check to ensure the generated class code is unique.